### PR TITLE
fix(angelone): add 5s timeout to local IP discovery socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - **AngelOne `get_order()`** — no longer raises `UnsupportedFeatureError`. Fetches full order
   book and filters by `order_id`; raises `OrderNotFoundError` if not found.
+- **AngelOne local IP timeout** — `_local_ip()` socket now has a 5s timeout to prevent hangs
+  on misconfigured networks.
 
 ## [0.8.4] - 2026-03-25
 

--- a/tt_connect/brokers/angelone/auth.py
+++ b/tt_connect/brokers/angelone/auth.py
@@ -21,7 +21,8 @@ _RENEW_URL = "https://apiconnect.angelbroking.com/rest/auth/angelbroking/user/v1
 def _local_ip() -> str:
     """Best-effort local IPv4 discovery required by AngelOne headers."""
     try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # Todo: Add 5 sec timeouts here
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(5.0)
         s.connect(("8.8.8.8", 80))
         ip = str(s.getsockname()[0])
         s.close()


### PR DESCRIPTION
## Summary

- `_local_ip()` UDP socket had no timeout — could hang indefinitely on misconfigured networks
- Added `s.settimeout(5.0)` before `s.connect()`
- Existing fallback to `127.0.0.1` on exception remains unchanged

## Release Impact

- No API changes — internal reliability improvement
- Prevents potential silent hang during AngelOne auth header construction

## Test Evidence

```
349 passed, 1 warning in 0.97s
ruff check: All checks passed!
mypy: Success: no issues found
```

## Risk and Rollback

- Minimal risk — one-line addition, existing fallback handles timeout exception
- Rollback: revert commit

## Checklist

- [x] Ran local quality gates + evidence
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Read `docs/RELEASE_VERSIONING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)