### PR TITLE
fix(instruments): deduplicate AngelOne rows, populate derivative names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- **AngelOne duplicate instruments** — symbols appearing as both index (`AMXIDX`) and plain
+  equity in AngelOne's master (e.g. NIFTY, BANKNIFTY) are now deduplicated; the index row
+  is kept, the spurious equity row is skipped.
+- **Empty display names for derivatives** — futures and options `name` column was always
+  `NULL`. Now populated with human-readable labels: `NIFTY FUT 27-Mar-2026` (futures),
+  `NIFTY 23000 CE 27-Mar-2026` (options). Applies to both brokers.
+
 ## [0.9.0] - 2026-03-25
 ### Added
 

--- a/tt_connect/brokers/angelone/parser.py
+++ b/tt_connect/brokers/angelone/parser.py
@@ -158,18 +158,30 @@ def parse(rows: list[dict[str, Any]]) -> ParsedInstruments:
     """
     result = ParsedInstruments()
 
+    # Track index symbols per exchange so equity pass can skip duplicates.
+    # AngelOne's master may list the same symbol (e.g. NIFTY) as both an
+    # AMXIDX index row and a plain NSE equity row — we keep only the index.
+    index_symbols: set[tuple[str, str]] = set()  # {(exchange, canonical_symbol)}
+
     for row in rows:
         instrument_type = (row.get("instrumenttype") or "").strip()
         exch_seg        = (row.get("exch_seg") or "").strip()
 
         # --- Indices ---
         if instrument_type == _INDEX_TYPE and exch_seg in _EQUITY_EXCHANGES:
-            result.indices.append(_parse_index(row))
+            parsed_idx = _parse_index(row)
+            index_symbols.add((parsed_idx.exchange, parsed_idx.symbol))
+            result.indices.append(parsed_idx)
             continue
 
         # --- Equities (instrumenttype is empty/NaN for plain equities) ---
         if not instrument_type and exch_seg in _EQUITY_EXCHANGES:
             symbol: str = (row.get("symbol") or "").strip()
+            canonical = symbol.removesuffix("-EQ")
+            exchange = exch_seg.strip()
+            # Skip symbols already captured as indices (e.g. NIFTY, BANKNIFTY)
+            if (exchange, canonical) in index_symbols:
+                continue
             # Keep plain equities (-EQ suffix) or heuristic plain ones; skip bonds/MFs/etc.
             if symbol.endswith("-EQ") or _is_plain_equity(row):
                 result.equities.append(_parse_equity(row))

--- a/tt_connect/core/store/manager.py
+++ b/tt_connect/core/store/manager.py
@@ -25,6 +25,34 @@ from tt_connect.core.exceptions import InstrumentManagerError, InstrumentStoreNo
 from tt_connect.core.store.queries import InstrumentQueries
 from tt_connect.core.store.schema import get_connection, init_schema
 
+# ---------------------------------------------------------------------------
+# Display-name helpers for derivative instruments
+# ---------------------------------------------------------------------------
+
+_MONTH_ABBR = [
+    "", "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+]
+
+
+def _fmt_expiry(expiry: date) -> str:
+    """Format expiry as ``DD-Mon-YYYY`` (e.g. ``27-Mar-2026``)."""
+    return f"{expiry.day:02d}-{_MONTH_ABBR[expiry.month]}-{expiry.year}"
+
+
+def _future_display_name(symbol: str, expiry: date) -> str:
+    """Human-readable future name: ``NIFTY FUT 27-Mar-2026``."""
+    return f"{symbol} FUT {_fmt_expiry(expiry)}"
+
+
+def _option_display_name(symbol: str, strike: float, option_type: str, expiry: date) -> str:
+    """Human-readable option name: ``NIFTY 23000 CE 27-Mar-2026``.
+
+    Strike is displayed as an integer when it has no fractional part.
+    """
+    strike_str = str(int(strike)) if strike == int(strike) else str(strike)
+    return f"{symbol} {strike_str} {option_type} {_fmt_expiry(expiry)}"
+
 logger = logging.getLogger(__name__)
 
 class ParsedInstrumentsLike(Protocol):
@@ -337,7 +365,9 @@ class InstrumentManager:
                 INSERT INTO instruments (exchange, symbol, segment, name, lot_size, tick_size)
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (fut.exchange, fut.symbol, fut.segment, None, fut.lot_size, fut.tick_size),
+                (fut.exchange, fut.symbol, fut.segment,
+                 _future_display_name(fut.symbol, fut.expiry),
+                 fut.lot_size, fut.tick_size),
             )
             instrument_id = cursor.lastrowid
 
@@ -389,7 +419,9 @@ class InstrumentManager:
                 INSERT INTO instruments (exchange, symbol, segment, name, lot_size, tick_size)
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (opt.exchange, opt.symbol, opt.segment, None, opt.lot_size, opt.tick_size),
+                (opt.exchange, opt.symbol, opt.segment,
+                 _option_display_name(opt.symbol, opt.strike, opt.option_type, opt.expiry),
+                 opt.lot_size, opt.tick_size),
             )
             instrument_id = cursor.lastrowid
 


### PR DESCRIPTION
## Summary
- **AngelOne duplicate instruments** — symbols appearing as both index (`AMXIDX`) and plain equity in AngelOne's master (e.g. NIFTY, BANKNIFTY) are now deduplicated; the index row is kept, the spurious equity row is skipped.
- **Empty display names for derivatives** — futures and options `name` column was always `NULL`. Now populated with human-readable labels: `NIFTY FUT 27-Mar-2026` (futures), `NIFTY 23000 CE 27-Mar-2026` (options). Applies to both brokers.

## Test plan
- [x] `make ci` passes (lint, typecheck, 349 tests, 81.78% coverage)
- [x] Verify AngelOne DB has no duplicate NIFTY rows after refresh
- [x] Verify futures/options `name` column is populated after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- AngelOne instrument ingestion now properly deduplicates overlapping symbols that appear as both index and equity rows, keeping only the index row and removing spurious duplicates.
- Futures and options derivatives now display human-readable names instead of remaining blank, with formatted expiry dates and strike information where applicable across all supported brokers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->